### PR TITLE
Simplified TOAST workflow implemented as the toast_filter_map function

### DIFF
--- a/paramfiles/paramfile_nersc.yaml
+++ b/paramfiles/paramfile_nersc.yaml
@@ -5,13 +5,13 @@
 # Define the directories
 ## Let's start with directories of data products
 data_dirs:
-  root: "/pscratch/sd/k/kwolz/bbdev/BBMASTER/data"
+  root: "/global/homes/c/chervias/CMBwork/SimonsObs/pipeline/data"
   map_directory: "maps"
   beam_directory: "beams"
   bandpasses_directory: "bandpasses"
 ## Then directories in which we will store outputs
 output_dirs: 
-  root: "/pscratch/sd/k/kwolz/bbdev/BBMASTER/outputs"
+  root: "/global/homes/c/chervias/CMBwork/SimonsObs/pipeline/output"
   mask_directory: "masks"
   pre_process_directory: "pre_processing"
   sims_directory: "sims"
@@ -111,13 +111,15 @@ sim_pars:
 
 ## Filtering transfer function related parameters
 tf_settings:
-  filtering_type: "m_filterer" # "m_filterer" or "toast"
+  filtering_type: "toast" # "m_filterer" or "toast"
   m_cut: 30 # necessary only if `filtering_type` is set to "m_filterer"
   toast: # necessary only if `filtering_type` is set to "toast"
-    schedule_file: "in_data/toast_schedule.txt"
-    par_file: "in_data/toast_pars.toml"
+    schedule: "/global/homes/c/chervias/CMBwork/SimonsObs/pipeline/data/schedule.txt"
+    instrument: "SAT1"
+    band: "SAT_f090"
+    thinfp: 8
 
-  tf_est_num_sims: 100
+  tf_est_num_sims: 4
 
   power_law_pars_tf_est:
     amp: 1.0

--- a/paramfiles/paramfile_toast-integration-carlos.yaml
+++ b/paramfiles/paramfile_toast-integration-carlos.yaml
@@ -1,0 +1,139 @@
+# Here is a sample .yaml file that can be used 
+# to store the metadata necessary to run the
+# SO BB pipeline.
+
+# Define the directories
+## Let's start with directories of data products
+data_dirs:
+  root: "/home/chervias/CMBwork/SimonsObs/SOOPERCOOL/data"
+  map_directory: "maps"
+  beam_directory: "beams"
+  bandpasses_directory: "bandpasses"
+## Then directories in which we will store outputs
+output_dirs: 
+  root: "/home/chervias/CMBwork/SimonsObs/SOOPERCOOL/output"
+  mask_directory: "masks"
+  pre_process_directory: "pre_processing"
+  sims_directory: "sims"
+  cell_transfer_directory: "cells_transfer"
+  cell_data_directory: "cells_data"
+  cell_sims_directory: "cells_sims"
+  coupling_directory: "couplings"
+
+##################################
+#    Metadata related to maps    #
+# ------------------------------ #
+#                                #
+# The structure of input splits  #
+# is the following:              #
+#                                #
+# tag:                           #
+#   file_root: ...               #
+#   n_splits: ...                #
+#   freq_tag: ...                #
+#   exp_tag: ...                 #
+##################################
+map_sets:
+  SAT1_f093:
+    file_root: "cmb_sat1_f093"
+    n_splits: 3          # Number of splits
+    freq_tag: 93         # Freq. tag (e.g. useful to coadd freqs)
+    exp_tag: "SAT1"      # Experiment tag (useful to get noise-bias free cross-split spectra)
+  SAT1_f145:
+    file_root: "cmb_sat1_f145"
+    n_splits: 3
+    freq_tag: 145
+    exp_tag: "SAT1"
+  # SAT2_f093:
+  #   file_root: "cmb_sat2_f093"
+  #   n_splits: 4
+  #   freq_tag: 93
+  #   exp_tag: "SAT2"
+  # SAT2_f145:
+  #   file_root: "cmb_sat2_f145"
+  #   n_splits: 4
+  #   freq_tag: 145
+  #   exp_tag: "SAT2"
+  # SAT3_f225:
+  #   file_root: "cmb_sat3_f225"
+  #   n_splits: 4
+  #   freq_tag: 225
+  #   exp_tag: "SAT3"
+  # SAT3_f285:
+  #   file_root: "cmb_sat3_f285"
+  #   n_splits: 4
+  #   freq_tag: 280
+  #   exp_tag: "SAT3"
+
+####################
+# Masking metadata #
+####################
+masks:
+  analysis_mask: "mask_apodized.fits"
+
+  binary_mask: "binary_mask.fits"
+  galactic_mask_root: "planck_galactic_mask"
+  point_source_mask: "point_source_mask.fits"
+
+  include_in_mask: ["galactic"]
+  gal_mask_mode: "gal070"
+  apod_radius: 4.0
+  apod_type: "C1"
+
+
+####################################
+# Metadata related to the analysis #
+####################################
+## General parameters
+general_pars:
+  nside: 256
+  lmin: 30
+  lmax: 600
+  deltal: 10
+  binning_file: "binning.npz"
+
+## Simulation related
+sim_pars:
+  hitmap_file: "/home/chervias/CMBwork/SimonsObs/SOOPERCOOL/data/FilterBin_hits.fits"
+  num_sims: 10
+  cosmology:
+    cosmomc_theta: 0.0104085
+    As: 2.1e-9
+    ombh2: 0.02237
+    omch2: 0.1200
+    ns: 0.9649
+    Alens: 1.0
+    tau: 0.0544
+    r: 0.01
+  mock_nsrcs: 80
+  mock_srcs_hole_radius: 40
+  
+
+## Filtering transfer function related parameters
+tf_settings:
+  filtering_type: "toast" # "m_filterer" or "toast"
+  m_cut: 30 # necessary only if `filtering_type` is set to "m_filterer"
+  toast: # necessary only if `filtering_type` is set to "toast"
+    schedule: "/home/chervias/CMBwork/SimonsObs/SOOPERCOOL/data/schedule.txt"
+    instrument: "SAT1"
+    band: "SAT_f090"
+    thinfp: 8
+    group_size: 4
+
+  tf_est_num_sims: 30
+
+  power_law_pars_tf_est:
+    amp: 1.0
+    delta_ell: 10
+    power_law_index: 2.
+  
+  power_law_pars_tf_val:
+    amp:
+      TT: 10.
+      EE: 1.
+      BB: 0.05
+      TE: 2.5
+      TB: 0.
+      EB: 0.
+    delta_ell: 10
+    power_law_index: 0.5

--- a/pipeline/filterer.py
+++ b/pipeline/filterer.py
@@ -23,7 +23,12 @@ def filter(args):
 
     elif meta.filtering_type == "toast":
         filter_func = utils.toast_filter_map
-        kwargs = {"schedule": meta.toast['schedule'], "thinfp": meta.toast['thinfp'], "instrument": meta.toast['instrument'], "band": meta.toast['band'], "group_size": meta.toast['group_size'], "nside": meta.nside, }
+        kwargs = {"schedule": meta.toast['schedule'],
+                  "thinfp": meta.toast['thinfp'],
+                  "instrument": meta.toast['instrument'],
+                  "band": meta.toast['band'],
+                  "group_size": meta.toast['group_size'],
+                  "nside": meta.nside, }
     else:
         raise NotImplementedError(f"Filterer type {meta.filtering_type} "
                                   "not implemented")
@@ -36,11 +41,17 @@ def filter(args):
             cases_list = ["pureE", "pureB"] if cl_type == "tf_est" else [None]
             for id_sim in range(meta.tf_est_num_sims):
                 for case in cases_list:
-                    map_file = meta.get_map_filename_transfer2(id_sim, cl_type, pure_type=case)
-                    map = hp.read_map(map_file, field=[0,1,2])
+                    map_file = meta.get_map_filename_transfer2(id_sim,
+                                                               cl_type,
+                                                               pure_type=case)
+                    map = hp.read_map(map_file, field=[0, 1, 2])
                     if meta.filtering_type == 'm_cut':
                         filtered_map = filter_func(map, mask, **kwargs)
-                        hp.write_map(map_file.replace(".fits", "_filtered.fits"), filtered_map, overwrite=True, dtype=np.float32)
+                        hp.write_map(map_file.replace(".fits",
+                                                      "_filtered.fits"),
+                                     filtered_map,
+                                     overwrite=True,
+                                     dtype=np.float32)
                     elif meta.filtering_type == 'toast':
                         filter_func(map_file, **kwargs)
 
@@ -49,13 +60,18 @@ def filter(args):
         for map_name in meta.maps_list:
             map_set, id_split = map_name.split("__")
             for id_sim in range(Nsims):
-                map_file = meta.get_map_filename(map_set, id_split, id_sim=id_sim if Nsims > 1 else None)
-                map = hp.read_map(map_file, field=[0,1,2])
-                if meta.filtering_type=='m_cut':
+                map_file = meta.get_map_filename(map_set, id_split,
+                                                 id_sim=id_sim if Nsims > 1
+                                                 else None)
+                map = hp.read_map(map_file, field=[0, 1, 2])
+                if meta.filtering_type == 'm_cut':
                     filtered_map = filter_func(map, mask, **kwargs)
-                    hp.write_map(map_file.replace(".fits", "_filtered.fits"), filtered_map, overwrite=True, dtype=np.float32)
-                elif meta.filtering_type=='toast':
+                    hp.write_map(map_file.replace(".fits", "_filtered.fits"),
+                                 filtered_map, overwrite=True,
+                                 dtype=np.float32)
+                elif meta.filtering_type == 'toast':
                     filter_func(map_file, **kwargs)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Filterer stage")

--- a/pipeline/filterer.py
+++ b/pipeline/filterer.py
@@ -23,8 +23,7 @@ def filter(args):
 
     elif meta.filtering_type == "toast":
         filter_func = utils.toast_filter_map
-        kwargs = {}
-
+        kwargs = {"schedule": meta.toast['schedule'], "thinfp": meta.toast['thinfp'], "instrument": meta.toast['instrument'], "band": meta.toast['band'], "nside": meta.nside, }
     else:
         raise NotImplementedError(f"Filterer type {meta.filtering_type} "
                                   "not implemented")
@@ -37,28 +36,26 @@ def filter(args):
             cases_list = ["pureE", "pureB"] if cl_type == "tf_est" else [None]
             for id_sim in range(meta.tf_est_num_sims):
                 for case in cases_list:
-                    map_file = meta.get_map_filename_transfer2(id_sim, cl_type,
-                                                               pure_type=case)
-                    map = hp.read_map(map_file, field=[0, 1, 2])
-                    filtered_map = filter_func(map, mask, **kwargs)
-                    print(map_file)
-                    hp.write_map(map_file.replace(".fits", "_filtered.fits"),
-                                 filtered_map, overwrite=True,
-                                 dtype=np.float32)
+                    map_file = meta.get_map_filename_transfer2(id_sim, cl_type, pure_type=case)
+                    map = hp.read_map(map_file, field=[0,1,2])
+                    if meta.filtering_type == 'm_cut':
+                        filtered_map = filter_func(map, mask, **kwargs)
+                        hp.write_map(map_file.replace(".fits", "_filtered.fits"), filtered_map, overwrite=True, dtype=np.float32)
+                    elif meta.filtering_type == 'toast':
+                        filter_func(map_file, **kwargs)
 
     if args.sims or args.data:
         Nsims = meta.num_sims if args.sims else 1
-
         for map_name in meta.maps_list:
             map_set, id_split = map_name.split("__")
             for id_sim in range(Nsims):
-                map_file = meta.get_map_filename(
-                    map_set, id_split, id_sim=id_sim if Nsims > 1 else None)
-                map = hp.read_map(map_file, field=[0, 1, 2])
-                filtered_map = filter_func(map, mask, **kwargs)
-                hp.write_map(map_file.replace(".fits", "_filtered.fits"),
-                             filtered_map, overwrite=True, dtype=np.float32)
-
+                map_file = meta.get_map_filename(map_set, id_split, id_sim=id_sim if Nsims > 1 else None)
+                map = hp.read_map(map_file, field=[0,1,2])
+                if meta.filtering_type=='m_cut':
+                    filtered_map = filter_func(map, mask, **kwargs)
+                    hp.write_map(map_file.replace(".fits", "_filtered.fits"), filtered_map, overwrite=True, dtype=np.float32)
+                elif meta.filtering_type=='toast':
+                    filter_func(map_file, **kwargs)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Filterer stage")
@@ -68,7 +65,6 @@ if __name__ == "__main__":
     mode.add_argument("--transfer", action="store_true")
     mode.add_argument("--sims", action="store_true")
     mode.add_argument("--data", action="store_true")
-
     args = parser.parse_args()
-
     filter(args)
+    

--- a/pipeline/filterer.py
+++ b/pipeline/filterer.py
@@ -25,12 +25,8 @@ def filter(args):
         filter_func = utils.toast_filter_map
         kwargs = {"schedule": meta.toast['schedule'], "thinfp": meta.toast['thinfp'], "instrument": meta.toast['instrument'], "band": meta.toast['band'], "nside": meta.nside, }
     else:
-<<<<<<< HEAD
         raise NotImplementedError(f"Filterer type {meta.filtering_type} "
                                   "not implemented")
-=======
-        raise NotImplementedError(f"Filterer type {meta.filtering_type} not implemented")
->>>>>>> 73611f3 (Fixing formatting stuff)
 
     # Read the mask
     mask = meta.read_mask("analysis")
@@ -47,17 +43,9 @@ def filter(args):
                         hp.write_map(map_file.replace(".fits", "_filtered.fits"), filtered_map, overwrite=True, dtype=np.float32)
                     elif meta.filtering_type == 'toast':
                         filter_func(map_file, **kwargs)
-<<<<<<< HEAD
 
     if args.sims or args.data:
         Nsims = meta.num_sims if args.sims else 1
-=======
-                    print(map_file)
-
-    if args.sims or args.data:
-        Nsims = meta.num_sims if args.sims else 1
-
->>>>>>> 73611f3 (Fixing formatting stuff)
         for map_name in meta.maps_list:
             map_set, id_split = map_name.split("__")
             for id_sim in range(Nsims):
@@ -77,13 +65,5 @@ if __name__ == "__main__":
     mode.add_argument("--transfer", action="store_true")
     mode.add_argument("--sims", action="store_true")
     mode.add_argument("--data", action="store_true")
-<<<<<<< HEAD
     args = parser.parse_args()
     filter(args)
-    
-=======
-
-    args = parser.parse_args()
-
-    filter(args)
->>>>>>> 73611f3 (Fixing formatting stuff)

--- a/pipeline/filterer.py
+++ b/pipeline/filterer.py
@@ -25,8 +25,12 @@ def filter(args):
         filter_func = utils.toast_filter_map
         kwargs = {"schedule": meta.toast['schedule'], "thinfp": meta.toast['thinfp'], "instrument": meta.toast['instrument'], "band": meta.toast['band'], "nside": meta.nside, }
     else:
+<<<<<<< HEAD
         raise NotImplementedError(f"Filterer type {meta.filtering_type} "
                                   "not implemented")
+=======
+        raise NotImplementedError(f"Filterer type {meta.filtering_type} not implemented")
+>>>>>>> 73611f3 (Fixing formatting stuff)
 
     # Read the mask
     mask = meta.read_mask("analysis")
@@ -43,9 +47,17 @@ def filter(args):
                         hp.write_map(map_file.replace(".fits", "_filtered.fits"), filtered_map, overwrite=True, dtype=np.float32)
                     elif meta.filtering_type == 'toast':
                         filter_func(map_file, **kwargs)
+<<<<<<< HEAD
 
     if args.sims or args.data:
         Nsims = meta.num_sims if args.sims else 1
+=======
+                    print(map_file)
+
+    if args.sims or args.data:
+        Nsims = meta.num_sims if args.sims else 1
+
+>>>>>>> 73611f3 (Fixing formatting stuff)
         for map_name in meta.maps_list:
             map_set, id_split = map_name.split("__")
             for id_sim in range(Nsims):
@@ -65,6 +77,13 @@ if __name__ == "__main__":
     mode.add_argument("--transfer", action="store_true")
     mode.add_argument("--sims", action="store_true")
     mode.add_argument("--data", action="store_true")
+<<<<<<< HEAD
     args = parser.parse_args()
     filter(args)
     
+=======
+
+    args = parser.parse_args()
+
+    filter(args)
+>>>>>>> 73611f3 (Fixing formatting stuff)

--- a/pipeline/filterer.py
+++ b/pipeline/filterer.py
@@ -23,7 +23,7 @@ def filter(args):
 
     elif meta.filtering_type == "toast":
         filter_func = utils.toast_filter_map
-        kwargs = {"schedule": meta.toast['schedule'], "thinfp": meta.toast['thinfp'], "instrument": meta.toast['instrument'], "band": meta.toast['band'], "nside": meta.nside, }
+        kwargs = {"schedule": meta.toast['schedule'], "thinfp": meta.toast['thinfp'], "instrument": meta.toast['instrument'], "band": meta.toast['band'], "group_size": meta.toast['group_size'], "nside": meta.nside, }
     else:
         raise NotImplementedError(f"Filterer type {meta.filtering_type} "
                                   "not implemented")

--- a/pipeline/pcler.py
+++ b/pipeline/pcler.py
@@ -329,11 +329,16 @@ def pcler(args):
         for id_sim in range(meta.tf_est_num_sims):
             fields = {"filtered": {}, "unfiltered": {}}
             for pure_type in ["pureE", "pureB"]:
-                map_file = meta.get_map_filename_transfer2(id_sim, "tf_est", pure_type=pure_type)
-                if meta.filtering_type=='toast':
-                    map_file_filtered = map_file.replace(".fits", "/FilterBin_filtered_map.fits")
+                map_file = meta.get_map_filename_transfer2(id_sim,
+                                                           "tf_est",
+                                                           pure_type=pure_type)
+                if meta.filtering_type == 'toast':
+                    map_file_filtered = map_file.replace(".fits",
+                                                         "/FilterBin_filtered\
+                                                         _map.fits")
                 else:
-                    map_file_filtered = map_file.replace(".fits", "_filtered.fits")
+                    map_file_filtered = map_file.replace(".fits",
+                                                         "_filtered.fits")
 
                 map = hp.read_map(map_file, field=[0, 1, 2])
                 map_filtered = hp.read_map(map_file_filtered, field=[0, 1, 2])
@@ -387,10 +392,12 @@ def pcler(args):
                                                                cl_type=cl_type)
                     print(map_file)
                     if filter_flag == "filtered":
-                        if meta.filtering_type=='toast':
-                            map_file = map_file.replace(".fits", "/FilterBin_filtered_map.fits")
+                        if meta.filtering_type == 'toast':
+                            map_file = map_file.replace(".fits", "/FilterBin\
+                                                        _filtered_map.fits")
                         else:
-                            map_file = map_file.replace(".fits", "_filtered.fits")
+                            map_file = map_file.replace(".fits",
+                                                        "_filtered.fits")
 
                     map = hp.read_map(map_file, field=[0, 1, 2])
 

--- a/pipeline/pcler.py
+++ b/pipeline/pcler.py
@@ -329,9 +329,11 @@ def pcler(args):
         for id_sim in range(meta.tf_est_num_sims):
             fields = {"filtered": {}, "unfiltered": {}}
             for pure_type in ["pureE", "pureB"]:
-                map_file = meta.get_map_filename_transfer2(id_sim, "tf_est",
-                                                           pure_type=pure_type)
-                map_file_filtered = map_file.replace(".fits", "_filtered.fits")
+                map_file = meta.get_map_filename_transfer2(id_sim, "tf_est", pure_type=pure_type)
+                if meta.filtering_type=='toast':
+                    map_file_filtered = map_file.replace(".fits", "/FilterBin_filtered_map.fits")
+                else:
+                    map_file_filtered = map_file.replace(".fits", "_filtered.fits")
 
                 map = hp.read_map(map_file, field=[0, 1, 2])
                 map_filtered = hp.read_map(map_file_filtered, field=[0, 1, 2])
@@ -385,7 +387,10 @@ def pcler(args):
                                                                cl_type=cl_type)
                     print(map_file)
                     if filter_flag == "filtered":
-                        map_file = map_file.replace(".fits", "_filtered.fits")
+                        if meta.filtering_type=='toast':
+                            map_file = map_file.replace(".fits", "/FilterBin_filtered_map.fits")
+                        else:
+                            map_file = map_file.replace(".fits", "_filtered.fits")
 
                     map = hp.read_map(map_file, field=[0, 1, 2])
 

--- a/pipeline/run_all.sh
+++ b/pipeline/run_all.sh
@@ -27,10 +27,10 @@ python filterer.py --globals ${paramfile} --transfer
 
 echo "Running filterer for sims"
 echo "-------------------------"
-python filterer.py --globals ${paramfile} --sims
+#python filterer.py --globals ${paramfile} --sims
 echo "Running filterer for data"
 echo "-------------------------"
-python filterer.py --globals ${paramfile} --data
+#python filterer.py --globals ${paramfile} --data
 
 echo "Running cl estimation for tf estimation"
 echo "---------------------------------------"
@@ -46,16 +46,32 @@ python pcler.py --globals ${paramfile} --tf_val
 
 echo "Running pcler on data"
 echo "---------------------"
+<<<<<<< HEAD
 python pcler.py --globals ${paramfile} --data --plots
+=======
+#python pcler.py --globals ${paramfile} --data
+>>>>>>> b6e3d16 (update to the bash file)
 
 echo "Running pcler on sims"
 echo "---------------------"
-python pcler.py --globals ${paramfile} --sims
+#python pcler.py --globals ${paramfile} --sims
 
 echo "Running coadder on data"
 echo "---------------------"
+<<<<<<< HEAD
 python coadder.py --globals ${paramfile} --data --plots --auto
 
 echo "Running coadder on sims"
 echo "---------------------"
 python coadder.py --globals ${paramfile} --sims
+=======
+#python coadder.py --globals ${paramfile} --data --plots
+
+echo "Running coadder on sims"
+echo "---------------------"
+#python coadder.py --globals ${paramfile} --sims
+
+echo "Transfer validation"
+echo "---------------------"
+python transfer_validator.py --globals ${paramfile}
+>>>>>>> b6e3d16 (update to the bash file)

--- a/pipeline/run_all_toast-integration-carlos.sh
+++ b/pipeline/run_all_toast-integration-carlos.sh
@@ -1,0 +1,63 @@
+paramfile='../paramfiles/paramfile_toast-integration-carlos.yaml'
+
+echo "Running pipeline with paramfile: ${paramfile}"
+
+echo "Pre-processing data..."
+echo "-------------------"
+python pre_processer.py --globals ${paramfile} --sims
+
+echo "Running mask stage..."
+echo "---------------------"
+#python mask_handler.py --globals ${paramfile}
+
+#echo "Running mock stage for data..."
+#echo "------------------------------"
+#python mocker.py --globals ${paramfile} 
+
+#echo "Running mock stage for sims..."
+#echo "------------------------------"
+#python mocker.py --globals ${paramfile} --sims
+
+echo "Running mcm..."
+echo "--------------"
+python mcmer.py --globals ${paramfile}
+
+echo "Running filterer for transfer"
+echo "-----------------------------"
+OMP_NUM_THREADS=2 mpiexec -n 4 python filterer.py --globals ${paramfile} --transfer
+
+#echo "Running filterer for sims"
+#echo "-------------------------"
+#python filterer.py --globals ${paramfile} --sims
+
+#echo "Running filterer for data"
+#echo "-------------------------"
+#python filterer.py --globals ${paramfile} --data
+
+echo "Running cl estimation for tf estimation"
+echo "---------------------------------------"
+python pcler.py --globals ${paramfile} --tf_est
+
+echo "Running transfer estimation"
+echo "---------------------------"
+python transfer.py --globals ${paramfile}
+
+echo "Running cl estimation for validation"
+echo "------------------------------------"
+python pcler.py --globals ${paramfile} --tf_val
+
+#echo "Running pcler on data"
+#echo "---------------------"
+#python pcler.py --globals ${paramfile} --data --plots
+
+#echo "Running pcler on sims"
+#echo "---------------------"
+#python pcler.py --globals ${paramfile} --sims
+
+#echo "Running coadder on sims"
+#echo "---------------------"
+#python coadder.py --globals ${paramfile} --sims
+
+#echo "Transfer validation"
+#echo "---------------------"
+#python transfer_validator.py --globals ${paramfile}

--- a/soopercool/toast_utils.py
+++ b/soopercool/toast_utils.py
@@ -1,53 +1,5 @@
-import numpy as np
-import datetime as dt
-import copy
-import argparse
-import os
-import sys
-import traceback
-import healpy as hp
-from astropy import units as u
-import warnings
-warnings.simplefilter("ignore")
-
-# Preprocess branch of sotodlib
-from sotodlib import coords, core
-import so3g
-import yaml
-from sotodlib.core import Context
-from sotodlib.hwp import hwp
-from sotodlib.tod_ops import fft_ops
-from sotodlib.tod_ops.fft_ops import calc_psd
-import logging
-from sotodlib.site_pipeline.preprocess_tod import _build_pipe_from_configs, _get_preprocess_context
-from sotodlib.coords import demod
-from sotodlib import coords
-
-# Use sotodlib.toast to set default 
-# object names used in toast
-import sotodlib.toast as sotoast
 import toast
 import toast.ops
-from toast.mpi import MPI, Comm
-from toast import spt3g as t3g
-if t3g.available:
-    from spt3g import core as c3g
-import sotodlib.toast.ops as so_ops
-import sotodlib.mapmaking
-# Import pixell
-import pixell.fft
-pixell.fft.engine = "fftw"
-
-# Plotting
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-from matplotlib import rc
-
-# For analysis of schedule
-import ephem
-import dateutil.parser
-import healpy as hp
-from toast import qarray as qa
 import subprocess
 
 
@@ -55,15 +7,25 @@ import subprocess
 A collection of useful functions written by SA, and/or other SO members.
 '''
 
+
 def run_bash_command(command):
+    """
+    """
+
     try:
-        result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(command, shell=True, check=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, text=True)
         print("Command output:", result.stdout)
         print("Command error (if any):", result.stderr)
     except subprocess.CalledProcessError as e:
         print("Error running command:", e)
 
+
 def apply_scanning(data, telescope, schedule):
+    """
+    """
+
     sim_gnd = toast.ops.SimGround(
             telescope=telescope,
             schedule=schedule,
@@ -74,21 +36,37 @@ def apply_scanning(data, telescope, schedule):
     sim_gnd.apply(data)
     return data, sim_gnd
 
+
 def apply_det_pointing_radec(data, sim_gnd):
-    det_pointing_radec =toast.ops.PointingDetectorSimple(name='det_pointing_radec', quats='quats_radex', shared_flags=None)
+    """
+    """
+
+    det_pointing_radec = toast.ops.PointingDetectorSimple(
+        name='det_pointing_radec',
+        quats='quats_radex',
+        shared_flags=None)
     det_pointing_radec.boresight = sim_gnd.boresight_radec
     det_pointing_radec.apply(data)
     return data, det_pointing_radec
 
+
 def apply_det_pointing_azel(data, sim_gnd):
-    det_pointing_azel =toast.ops.PointingDetectorSimple(name='det_pointing_azel', quats='quats_azel', shared_flags=None)
+    """
+    """
+
+    det_pointing_azel = toast.ops.PointingDetectorSimple(
+        name='det_pointing_azel', quats='quats_azel', shared_flags=None)
     det_pointing_azel.boresight = sim_gnd.boresight_azel
     det_pointing_azel.apply(data)
     return data, det_pointing_azel
 
+
 def apply_pixels_radec(data, det_pointing_radec, nside):
+    """
+    """
+
     pixels_radec = toast.ops.pixels_healpix.PixelsHealpix(
-        name="pixels_radec", 
+        name="pixels_radec",
         pixels='pixels',
         nside=nside,
         nside_submap=8,)
@@ -96,43 +74,66 @@ def apply_pixels_radec(data, det_pointing_radec, nside):
     pixels_radec.apply(data)
     return data, pixels_radec
 
+
 def apply_weights_radec(data, det_pointing_radec):
+    """
+    """
+
     weights_radec = toast.ops.stokes_weights.StokesWeights(
-        mode = "IQU", # The Stokes weights to generate (I or IQU)
-        name = "weights_radec", # The 'name' of this class instance,
-        hwp_angle = "hwp_angle"
-    )
+        mode="IQU",  # The Stokes weights to generate (I or IQU)
+        name="weights_radec",  # The 'name' of this class instance,
+        hwp_angle="hwp_angle")
     weights_radec.detector_pointing = det_pointing_radec
     weights_radec.apply(data)
     return data, weights_radec
 
+
 def apply_scan_map(data, file, pixels_radec, weights_radec):
+    """
+    """
+
     scan_map = toast.ops.ScanHealpixMap(
         name='scan_map',
         file=file)
-    scan_map.pixel_pointing= pixels_radec
+    scan_map.pixel_pointing = pixels_radec
     scan_map.stokes_weights = weights_radec
     scan_map.apply(data)
     return data, scan_map
 
+
 def apply_noise_model(data):
+    """
+    """
+
     noise_model = toast.ops.DefaultNoiseModel(
         name='default_model', noise_model='noise_model')
     noise_model.apply(data)
     return data, noise_model
 
+
 def apply_sim_noise(data):
+    """
+    """
+
     sim_noise = toast.ops.SimNoise()
     sim_noise.apply(data)
     return data, sim_noise
 
+
 def create_binner(pixels_radec, det_pointing_radec):
+    """
+    """
+
     binner = toast.ops.BinMap()
     binner.pixel_pointing = pixels_radec
     binner.pixel_pointing.detector_pointing = det_pointing_radec
     return binner
 
+
 def apply_demodulation(data, weights_radec, sim_gnd, binner):
+    """
+    """
+
     demod = toast.ops.Demodulate()
     demod.stokes_weights = weights_radec
     demod.hwp_angle = sim_gnd.hwp_angle
@@ -141,30 +142,16 @@ def apply_demodulation(data, weights_radec, sim_gnd, binner):
     binner.stokes_weights = demod_weights
     return data, demod_weights
 
+
 def make_filterbin(data, binner, output_dir):
+    """
+    """
+
     filterbin = toast.ops.FilterBin()
     filterbin.binning = binner
     filterbin.output_dir = output_dir
     filterbin.write_hits = False
     filterbin.write_cov = False
     filterbin.write_rcond = False
-    #filterbin.write_hits = True
+    # filterbin.write_hits = True
     filterbin.apply(data)
-
-def preprocess(aman):
-    # Let's load the config file created 
-    configs="./preprocess/pipe_s0002_sim_preprocess.yaml"
-    configs = yaml.safe_load(open(configs, "r"))
-    # And build the pipeline including the filters 
-    # specified in the config
-    pipe = _build_pipe_from_configs(configs)
-    proc_aman = core.AxisManager(aman.dets, aman.samps)
-    for pi in np.arange(3):
-        # 1) Detrended
-        # 2) Apodize
-        # 3) Demodulate
-        process = pipe[pi]
-        #print(f"Processing {process.name}")
-        process.process(aman, proc_aman)
-        process.calc_and_save(aman, proc_aman)
-    return aman, proc_aman

--- a/soopercool/toast_utils.py
+++ b/soopercool/toast_utils.py
@@ -1,0 +1,170 @@
+import numpy as np
+import datetime as dt
+import copy
+import argparse
+import os
+import sys
+import traceback
+import healpy as hp
+from astropy import units as u
+import warnings
+warnings.simplefilter("ignore")
+
+# Preprocess branch of sotodlib
+from sotodlib import coords, core
+import so3g
+import yaml
+from sotodlib.core import Context
+from sotodlib.hwp import hwp
+from sotodlib.tod_ops import fft_ops
+from sotodlib.tod_ops.fft_ops import calc_psd
+import logging
+from sotodlib.site_pipeline.preprocess_tod import _build_pipe_from_configs, _get_preprocess_context
+from sotodlib.coords import demod
+from sotodlib import coords
+
+# Use sotodlib.toast to set default 
+# object names used in toast
+import sotodlib.toast as sotoast
+import toast
+import toast.ops
+from toast.mpi import MPI, Comm
+from toast import spt3g as t3g
+if t3g.available:
+    from spt3g import core as c3g
+import sotodlib.toast.ops as so_ops
+import sotodlib.mapmaking
+# Import pixell
+import pixell.fft
+pixell.fft.engine = "fftw"
+
+# Plotting
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib import rc
+
+# For analysis of schedule
+import ephem
+import dateutil.parser
+import healpy as hp
+from toast import qarray as qa
+import subprocess
+
+
+'''
+A collection of useful functions written by SA, and/or other SO members.
+'''
+
+def run_bash_command(command):
+    try:
+        result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        print("Command output:", result.stdout)
+        print("Command error (if any):", result.stderr)
+    except subprocess.CalledProcessError as e:
+        print("Error running command:", e)
+
+def apply_scanning(data, telescope, schedule):
+    sim_gnd = toast.ops.SimGround(
+            telescope=telescope,
+            schedule=schedule,
+            weather="atacama",
+            hwp_angle='hwp_angle',
+            hwp_rpm=120,
+        )
+    sim_gnd.apply(data)
+    return data, sim_gnd
+
+def apply_det_pointing_radec(data, sim_gnd):
+    det_pointing_radec =toast.ops.PointingDetectorSimple(name='det_pointing_radec', quats='quats_radex', shared_flags=None)
+    det_pointing_radec.boresight = sim_gnd.boresight_radec
+    det_pointing_radec.apply(data)
+    return data, det_pointing_radec
+
+def apply_det_pointing_azel(data, sim_gnd):
+    det_pointing_azel =toast.ops.PointingDetectorSimple(name='det_pointing_azel', quats='quats_azel', shared_flags=None)
+    det_pointing_azel.boresight = sim_gnd.boresight_azel
+    det_pointing_azel.apply(data)
+    return data, det_pointing_azel
+
+def apply_pixels_radec(data, det_pointing_radec, nside):
+    pixels_radec = toast.ops.pixels_healpix.PixelsHealpix(
+        name="pixels_radec", 
+        pixels='pixels',
+        nside=nside,
+        nside_submap=8,)
+    pixels_radec.detector_pointing = det_pointing_radec
+    pixels_radec.apply(data)
+    return data, pixels_radec
+
+def apply_weights_radec(data, det_pointing_radec):
+    weights_radec = toast.ops.stokes_weights.StokesWeights(
+        mode = "IQU", # The Stokes weights to generate (I or IQU)
+        name = "weights_radec", # The 'name' of this class instance,
+        hwp_angle = "hwp_angle"
+    )
+    weights_radec.detector_pointing = det_pointing_radec
+    weights_radec.apply(data)
+    return data, weights_radec
+
+def apply_scan_map(data, file, pixels_radec, weights_radec):
+    scan_map = toast.ops.ScanHealpixMap(
+        name='scan_map',
+        file=file)
+    scan_map.pixel_pointing= pixels_radec
+    scan_map.stokes_weights = weights_radec
+    scan_map.apply(data)
+    return data, scan_map
+
+def apply_noise_model(data):
+    noise_model = toast.ops.DefaultNoiseModel(
+        name='default_model', noise_model='noise_model')
+    noise_model.apply(data)
+    return data, noise_model
+
+def apply_sim_noise(data):
+    sim_noise = toast.ops.SimNoise()
+    sim_noise.apply(data)
+    return data, sim_noise
+
+def create_binner(pixels_radec, det_pointing_radec):
+    binner = toast.ops.BinMap()
+    binner.pixel_pointing = pixels_radec
+    binner.pixel_pointing.detector_pointing = det_pointing_radec
+    return binner
+
+def apply_demodulation(data, weights_radec, sim_gnd, binner):
+    demod = toast.ops.Demodulate()
+    demod.stokes_weights = weights_radec
+    demod.hwp_angle = sim_gnd.hwp_angle
+    data = demod.apply(data)
+    demod_weights = toast.ops.StokesWeightsDemod()
+    binner.stokes_weights = demod_weights
+    return data, demod_weights
+
+def make_filterbin(data, binner, output_dir):
+    filterbin = toast.ops.FilterBin()
+    filterbin.binning = binner
+    filterbin.output_dir = output_dir
+    filterbin.write_hits = False
+    filterbin.write_cov = False
+    filterbin.write_rcond = False
+    #filterbin.write_hits = True
+    filterbin.apply(data)
+
+def preprocess(aman):
+    # Let's load the config file created 
+    configs="./preprocess/pipe_s0002_sim_preprocess.yaml"
+    configs = yaml.safe_load(open(configs, "r"))
+    # And build the pipeline including the filters 
+    # specified in the config
+    pipe = _build_pipe_from_configs(configs)
+    proc_aman = core.AxisManager(aman.dets, aman.samps)
+    for pi in np.arange(3):
+        # 1) Detrended
+        # 2) Apodize
+        # 3) Demodulate
+        process = pipe[pi]
+        #print(f"Processing {process.name}")
+        process.process(aman, proc_aman)
+        process.calc_and_save(aman, proc_aman)
+    return aman, proc_aman

--- a/soopercool/utils.py
+++ b/soopercool/utils.py
@@ -7,6 +7,7 @@ import pymaster as nmt
 import healpy as hp
 import sacc
 import camb
+from .toast_utils import *
 
 
 def get_pcls(man, fnames, names, fname_out, mask, binning, winv=None):
@@ -227,12 +228,58 @@ def m_filter_map(map, mask, m_cut):
 
     return hp.alm2map(alms, nside=nside, lmax=lmax)
 
+def toast_filter_map(map, schedule, thinfp, instrument, band, nside ):
+    import time
+    start_time = time.time()
 
-def toast_filter_map(map, mask):
-    """
-    """
-    raise NotImplementedError("TOAST filtering not implemented yet.")
+    output_dir = map.replace('.fits','/')
+    os.makedirs(output_dir,exist_ok=True)
 
+    # Initialize schedule
+    schedule_ = toast.schedule.GroundSchedule()
+
+    if not os.path.exists(schedule):
+        raise FileNotFoundError(f"The corresponding schedule file {schedule} is not stored.")
+
+    # Read schedule
+    print('Read schedule')
+    schedule_.read(schedule)
+
+    # Setup focal plane
+    print('Initialize focal plane and telescope')
+    focalplane = sotoast.SOFocalplane(hwfile=None,
+                                      telescope=instrument, #schedule.telescope_name,
+                                      sample_rate=40 * u.Hz,
+                                      bands=band,
+                                      wafer_slots='w25', 
+                                      tube_slots=None,
+                                      thinfp=thinfp,
+                                      comm=None)
+    # Setup telescope
+    telescope = toast.Telescope(name=instrument, #schedule.telescope_name,
+                                focalplane=focalplane, 
+                                site=toast.GroundSite("Atacama", schedule_.site_lat,
+                                                      schedule_.site_lon, schedule_.site_alt))
+    # Create data object
+    data = toast.Data()
+
+    # Apply filters
+    print('Apply filters')
+    _, sim_gnd = apply_scanning(data, telescope, schedule_) # HWP info in here, + all sim_ground stuff
+    data, det_pointing_radec = apply_det_pointing_radec(data, sim_gnd)
+    data, pixels_radec = apply_pixels_radec(data, det_pointing_radec, nside)
+    data, weights_radec = apply_weights_radec(data, det_pointing_radec)
+    data, noise_model = apply_noise_model(data)
+    # Scan map
+    print('Scan input map')
+    data, scan_map = apply_scan_map(data, map, pixels_radec, weights_radec)
+    # create the binner 
+    binner = create_binner(pixels_radec, det_pointing_radec)
+    #demodulate
+    data, weights_radec = apply_demodulation(data, weights_radec, sim_gnd, binner)
+    #map filterbin
+    make_filterbin(data, binner, output_dir)
+    return ;
 
 def get_split_pairs_from_coadd_ps_name(map_set1, map_set2,
                                        all_splits_ps_names,


### PR DESCRIPTION
A simplified SO TOAST workflow is implemented as the `toast_filter_map` function in `utils.py`. We started from the work that Susanna did [here](https://github.com/susannaaz/BBFLP/blob/master/Sec4_Simulate_TOD_breakdown.ipynb) and [here](https://github.com/simonsobs/SOOPERCOOL/blob/9ccdf898edef2de7b391210b889a29deb94701a0/pipeline/filterer_toast.py#L9) and then added the demodulate and filterbin operators from toast to run the complete workflow.