### PR TITLE
Correcting mask handling

### DIFF
--- a/paramfiles/paramfile_SAT.yaml
+++ b/paramfiles/paramfile_SAT.yaml
@@ -55,9 +55,10 @@ masks:
   galactic_mask_root: "planck_galactic_mask"
   point_source_mask: "point_source_mask.fits"
 
-  include_in_mask: ["galactic"]
+  include_in_mask: []
   gal_mask_mode: "gal070"
-  apod_radius: 4.0
+  apod_radius: 10.0
+  apod_radius_point_source: 4.0
   apod_type: "C1"
 
 ####################################

--- a/pipeline/filterer.py
+++ b/pipeline/filterer.py
@@ -18,7 +18,7 @@ def filter(args):
     filter_map = meta.get_filter_function()
 
     # Read the mask
-    mask = meta.read_mask("analysis")
+    mask = meta.read_mask("binary")
 
     meta.timer.start(f"Filter {meta.tf_est_num_sims} sims for TF estimation.")
     if args.transfer:

--- a/pipeline/mask_handler.py
+++ b/pipeline/mask_handler.py
@@ -3,7 +3,6 @@ import healpy as hp
 from soopercool.utils import (random_src_mask, get_apodized_mask_from_nhits,
                               get_binary_mask_from_nhits)
 from soopercool import BBmeta
-import pymaster as nmt
 import numpy as np
 import os
 import matplotlib.pyplot as plt

--- a/pipeline/mask_handler.py
+++ b/pipeline/mask_handler.py
@@ -18,84 +18,29 @@ def mask_handler(args):
 
     timeout_seconds = 300  # Set the timeout [sec] for the socket
 
+    if args.plots:
+        cmap = cm.YlOrRd
+        cmap.set_under("w")
+
     os.makedirs(mask_dir, exist_ok=True)
 
     # Download SAT hits map
     print("Download and save SAT hits map ...")
     sat_nhits_file = meta.hitmap_file
-    if not os.path.exists(sat_nhits_file):
-        urlpref = "https://portal.nersc.gov/cfs/sobs/users/so_bb/"
-        url = f"{urlpref}norm_nHits_SA_35FOV_ns512.fits"
-        # Open the URL with a timeout
-        with urllib.request.urlopen(url, timeout=timeout_seconds):
-            # Retrieve the file and save it locally
-            urllib.request.urlretrieve(url, filename=sat_nhits_file)
-
-    # Download SAT apodized mask used in the SO BB
-    # pipeline paper (https://arxiv.org/abs/2302.04276)
-    print("Download and save SAT apodized mask ...")
-    sat_apo_file = meta._get_analysis_mask_name()
-    if not os.path.exists(sat_apo_file):
-        urlpref = "https://portal.nersc.gov/cfs/sobs/users/so_bb/"
-        url = f"{urlpref}apodized_mask_bbpipe_paper.fits"
-        with urllib.request.urlopen(url, timeout=timeout_seconds):
-            urllib.request.urlretrieve(url, filename=sat_apo_file)
-            sat_apo_mask = hp.read_map(sat_apo_file, field=0)
-            sat_apo_mask = hp.ud_grade(sat_apo_mask, meta.nside)
-            hp.write_map(sat_apo_file, sat_apo_mask, overwrite=True,
-                         dtype=np.int32)
-
-    # Download galactic mask
-    if "galactic" in meta.masks["include_in_mask"]:
-        print("Download and save planck galactic masks ...")
-        mask_p15_file = f"{mask_dir}/mask_planck2015.fits"
-        if not os.path.exists(mask_p15_file):
-            urlpref = "http://pla.esac.esa.int/pla/aio/"
-            urlpref = f"{urlpref}product-action?MAP.MAP_ID="
-            url = f"{urlpref}HFI_Mask_GalPlane-apo0_2048_R2.00.fits"
-            with urllib.request.urlopen(url, timeout=timeout_seconds):
-                urllib.request.urlretrieve(url, filename=mask_p15_file)
-
-        # Save different galactic masks
-        gal_keys = ["GAL020", "GAL040", "GAL060", "GAL070",
-                    "GAL080", "GAL090", "GAL097", "GAL099"]
-        for id_key, gal_key in enumerate(gal_keys):
-            meta.timer.start(f"gal{id_key}")
-            fname = f"{mask_dir}/{meta.masks['galactic_mask_root']}_{gal_key.lower()}.fits"  # noqa
-            gal_mask_p15 = hp.read_map(mask_p15_file, field=id_key)
-            if not os.path.exists(fname):
-                # Rotate in equatorial coordinates
-                r = hp.Rotator(coord=['G', 'C'])
-                gal_mask_p15 = r.rotate_map_pixel(gal_mask_p15)
-                gal_mask_p15 = hp.ud_grade(gal_mask_p15, meta.nside)
-                gal_mask_p15 = np.where(gal_mask_p15 > 0.5, 1, 0)
-                hp.write_map(
-                    fname,
-                    gal_mask_p15,
-                    overwrite=True,
-                    dtype=np.int32
-                )
-            meta.timer.stop(f"gal{id_key}",
-                            f"Galactic mask {gal_key} projection",
-                            args.verbose)
-
-            if args.plots:
-                cmap = cm.YlOrRd
-                cmap.set_under("w")
-                plt.figure(figsize=(16, 9))
-                hp.mollview(gal_mask_p15, cmap=cmap, cbar=False)
-                hp.graticule()
-                plt.savefig(fname.replace("fits", "png"))
+    # if not os.path.exists(sat_nhits_file):
+    urlpref = "https://portal.nersc.gov/cfs/sobs/users/so_bb/"
+    url = f"{urlpref}norm_nHits_SA_35FOV_ns512.fits"
+    # Open the URL with a timeout
+    with urllib.request.urlopen(url, timeout=timeout_seconds):
+        # Retrieve the file and save it locally
+        urllib.request.urlretrieve(url, filename=sat_nhits_file)
 
     # Generate binary survey mask from a hitmap
     meta.timer.start("Computing binary mask")
-    binary_mask_file = meta._get_binary_mask_name()
-    if not os.path.exists(binary_mask_file):
-        sat_nhits = hp.read_map(sat_nhits_file)
-        binary_maskk = (sat_nhits > 0).astype(float)
-        binary_mask = hp.ud_grade(binary_maskk, meta.nside)
-        meta.save_mask("binary", binary_mask, overwrite=True)
-    binary_mask = hp.read_map(binary_mask_file)
+    sat_nhits = hp.read_map(sat_nhits_file)
+    binary_maskk = (sat_nhits > 0).astype(float)
+    binary_mask = hp.ud_grade(binary_maskk, meta.nside)
+    meta.save_mask("binary", binary_mask, overwrite=True)
     meta.timer.stop("Computing binary mask", args.verbose)
 
     if args.plots:
@@ -104,43 +49,103 @@ def mask_handler(args):
         hp.graticule()
         plt.savefig(meta.binary_mask_name.replace('.fits', '.png'))
 
-    # Generate mock point source mask
-    if "point_source" in meta.masks["include_in_mask"]:
-        # Generate a mock source mask
-        meta.timer.start("ps_mask")
-        nsrcs = meta.mock_nsrcs
-        mask_radius_arcmin = meta.mock_srcs_hole_radius
-        ps_mask = random_src_mask(binary_mask, nsrcs,
-                                  mask_radius_arcmin)
-        meta.save_mask("point_source", ps_mask, overwrite=True)
-        meta.timer.stop("ps_mask",
-                        "Generate mock point source mask", args.verbose)
+    if not args.self_assemble:
+        # Download SAT apodized mask used in the SO BB
+        # pipeline paper (https://arxiv.org/abs/2302.04276)
+        # and use as analysis mask
+        print("Download and save SAT apodized mask ...")
+        sat_apo_file = meta._get_analysis_mask_name()
+        urlpref = "https://portal.nersc.gov/cfs/sobs/users/so_bb/"
+        url = f"{urlpref}apodized_mask_bbpipe_paper.fits"
+        with urllib.request.urlopen(url, timeout=timeout_seconds):
+            urllib.request.urlretrieve(url, filename=sat_apo_file)
+            sat_apo_mask = hp.read_map(sat_apo_file, field=0)
+            sat_apo_mask = hp.ud_grade(sat_apo_mask, meta.nside)
+            meta.save_mask("analysis", sat_apo_mask, overwrite=True)
+    else:
+        # Assemble custom analysis mask from hits map, Galactic mask and
+        # point source mask
+        raise NotImplementedError("Can only download analysis mask for now")
 
-        if args.plots:
-            plt.figure(figsize=(16, 9))
-            hp.mollview(ps_mask, cmap=cmap, cbar=False)
-            hp.graticule()
-            plt.savefig(meta.point_source_mask_name.replace(".fits", ".png"))
+        # Download galactic mask
+        if "galactic" in meta.masks["include_in_mask"]:
+            print("Download and save planck galactic masks ...")
+            mask_p15_file = f"{mask_dir}/mask_planck2015.fits"
+            if not os.path.exists(mask_p15_file):
+                urlpref = "http://pla.esac.esa.int/pla/aio/"
+                urlpref = f"{urlpref}product-action?MAP.MAP_ID="
+                url = f"{urlpref}HFI_Mask_GalPlane-apo0_2048_R2.00.fits"
+                with urllib.request.urlopen(url, timeout=timeout_seconds):
+                    urllib.request.urlretrieve(url, filename=mask_p15_file)
 
-    # Add the masks
-    meta.timer.start("final_mask")
-    final_mask = binary_mask.copy()
-    if "galactic" in meta.masks["include_in_mask"]:
-        mask = meta.read_mask("galactic")
-        final_mask *= mask
-    if "point_source" in meta.masks["include_in_mask"]:
-        mask = meta.read_mask("point_source")
-        final_mask *= mask
+            # Save different galactic masks
+            gal_keys = ["GAL020", "GAL040", "GAL060", "GAL070",
+                        "GAL080", "GAL090", "GAL097", "GAL099"]
+            for id_key, gal_key in enumerate(gal_keys):
+                meta.timer.start(f"gal{id_key}")
+                fname = f"{mask_dir}/{meta.masks['galactic_mask_root']}_{gal_key.lower()}.fits"  # noqa
+                gal_mask_p15 = hp.read_map(mask_p15_file, field=id_key)
+                if not os.path.exists(fname):
+                    # Rotate in equatorial coordinates
+                    r = hp.Rotator(coord=['G', 'C'])
+                    gal_mask_p15 = r.rotate_map_pixel(gal_mask_p15)
+                    gal_mask_p15 = hp.ud_grade(gal_mask_p15, meta.nside)
+                    gal_mask_p15 = np.where(gal_mask_p15 > 0.5, 1, 0)
+                    hp.write_map(
+                        fname,
+                        gal_mask_p15,
+                        overwrite=True,
+                        dtype=np.int32
+                    )
+                meta.timer.stop(f"gal{id_key}",
+                                f"Galactic mask {gal_key} projection",
+                                args.verbose)
 
-    final_mask = nmt.mask_apodization(final_mask, meta.masks["apod_radius"],
-                                      apotype=meta.masks["apod_type"])
-    meta.save_mask("analysis", final_mask, overwrite=True)
-    meta.timer.stop("final_mask", "Compute and save final analysis mask",
-                    args.verbose)
+                if args.plots:
+                    plt.figure(figsize=(16, 9))
+                    hp.mollview(gal_mask_p15, cmap=cmap, cbar=False)
+                    hp.graticule()
+                    plt.savefig(fname.replace("fits", "png"))
+
+        # Generate mock point source mask
+        if "point_source" in meta.masks["include_in_mask"]:
+            meta.timer.start("ps_mask")
+            nsrcs = meta.mock_nsrcs
+            mask_radius_arcmin = meta.mock_srcs_hole_radius
+            ps_mask = random_src_mask(binary_mask, nsrcs,
+                                      mask_radius_arcmin)
+            meta.save_mask("point_source", ps_mask, overwrite=True)
+            meta.timer.stop("ps_mask",
+                            "Generate mock point source mask", args.verbose)
+
+            if args.plots:
+                plt.figure(figsize=(16, 9))
+                hp.mollview(ps_mask, cmap=cmap, cbar=False)
+                hp.graticule()
+                plt.savefig(meta.point_source_mask_name.replace(".fits",
+                                                                ".png"))
+
+        # Add the masks
+        meta.timer.start("final_mask")
+        final_mask = binary_mask.copy()
+        if "galactic" in meta.masks["include_in_mask"]:
+            mask = meta.read_mask("galactic")
+            final_mask *= mask
+        if "point_source" in meta.masks["include_in_mask"]:
+            mask = meta.read_mask("point_source")
+            final_mask *= mask
+
+        # TODO: Implement thresholding and smoothing
+        final_mask = nmt.mask_apodization(final_mask,
+                                          meta.masks["apod_radius"],
+                                          apotype=meta.masks["apod_type"])
+        meta.save_mask("analysis", final_mask, overwrite=True)
+        meta.timer.stop("final_mask", "Compute and save final analysis mask",
+                        args.verbose)
 
     if args.plots:
         plt.figure(figsize=(16, 9))
-        hp.mollview(final_mask, cmap=cmap, cbar=False)
+        hp.mollview(meta.read_mask("analysis"), cmap=cmap, cbar=False)
         hp.graticule()
         plt.savefig(meta.analysis_mask_name.replace(".fits", ".png"))
 
@@ -152,6 +157,7 @@ if __name__ == "__main__":
                         help="Path to yaml with global parameters")
     parser.add_argument("--plots", action="store_true")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--self_assemble", action="store_true")
     args = parser.parse_args()
 
     mask_handler(args)

--- a/pipeline/mcmer.py
+++ b/pipeline/mcmer.py
@@ -35,7 +35,7 @@ def mcmer(args):
     w = nmt.NmtWorkspace()
     w.compute_coupling_matrix(field_spin0, field_spin2, nmt_bins, is_teb=True)
 
-    nl = meta.lmax + 1
+    nl = 3*meta.nside
     nspec = 7
     mcm = np.transpose(w.get_coupling_matrix().reshape([nl, nspec, nl, nspec]),
                        axes=[1, 0, 3, 2])

--- a/pipeline/pre_processer.py
+++ b/pipeline/pre_processer.py
@@ -12,8 +12,7 @@ def pre_processer(args):
     meta = BBmeta(args.globals)
 
     # First step : create bandpower edges / binning_file
-    bin_low, bin_high, bin_center = utils.create_binning(meta.lmin,
-                                                         meta.lmax,
+    bin_low, bin_high, bin_center = utils.create_binning(meta.nside,
                                                          meta.deltal)
     np.savez(meta.path_to_binning, bin_low=bin_low, bin_high=bin_high,
              bin_center=bin_center)

--- a/pipeline/run_all.sh
+++ b/pipeline/run_all.sh
@@ -13,7 +13,7 @@ echo "------------------------------------------------------------"
 echo "Pre-processing data..."
 echo "-------------------"
 python pre_processer.py --globals ${paramfile} --sims
-python mask_handler.py --globals ${paramfile}
+python mask_handler.py --globals ${paramfile} --self_assemble
 
 echo "Running mock stage for data..."
 echo "------------------------------"

--- a/pipeline/transfer.py
+++ b/pipeline/transfer.py
@@ -26,7 +26,7 @@ def transfer(args):
 
     nmt_binning = meta.read_nmt_binning()
     n_bins = nmt_binning.get_n_bands()
-    nl = meta.lmax + 1
+    nl = 3*meta.nside
 
     # Load the pseudo-cl matrices for each simulation
     # Should be (n_comb_pure, n_comb_mode, n_bins)
@@ -190,53 +190,3 @@ if __name__ == "__main__":
     parser.add_argument("--globals", type=str, help="Path to the yaml file")
     args = parser.parse_args()
     transfer(args)
-
-_ = """
-    # Save to file
-    fname = man.get_filename('transfer_function', o.output_dir)
-    np.savez(fname,
-             mcm=mcm,  # We save the original mcm for completeness
-             bmcm=bmcm,  # We save the original mcm for completeness
-             transfer_function=trans,
-             transfer_function_error=etrans,
-             bpw_windows=bpw_windows,
-             wcal_inv=wcal_inv)
-
-    if o.plot:
-        # Reliable ells
-        goodl = leff < 2*man.nside
-
-        # Now recover Cl_filt from Cl_in
-        cl_filt_r = np.einsum('ijl,kjl->kil', trans, cl_in)
-        combs = ['EE', 'EB', 'BE', 'BB']
-        for i, comb in enumerate(combs):
-            plt.figure()
-            plt.title(comb)
-            plt.plot(leff[goodl], cl_filt[i, i][goodl], 'k-')
-            plt.plot(leff[goodl], cl_filt_r[i, i][goodl], 'r:')
-        plt.show()
-        exit(1)
-
-        for i1, comb1 in enumerate(combs):
-            for i2, comb2 in enumerate(combs):
-                plt.figure()
-                plt.title(f'{comb2}->{comb1}')
-                plt.plot(leff[goodl], trans[i1, i2][goodl], 'k-')
-        plt.show()
-
-        for i1, c1 in enumerate(['EE', 'EB', 'BE', 'BB']):
-            plt.figure()
-            plt.title(f'{c1}->XY')
-            for i2, (c2, col) in enumerate(zip(['EE', 'EB', 'BE', 'BB'],
-                                               ['r', 'b', 'y', 'c'])):
-                p = cl_th[i1, i2]
-
-                plt.plot(leff[goodl], p[goodl], col+'-', label=f'XY={c2}')
-                plt.plot(leff[goodl], -p[goodl], col+':')
-                plt.errorbar(leff[goodl], np.fabs(cl_in[i1, i2][goodl]),
-                             yerr=ecl_in[i1, i2][goodl]/np.sqrt(nsims),
-                             fmt=col+'.')
-            plt.loglog()
-            plt.legend()
-        plt.show()
-"""

--- a/pipeline/transfer_validator.py
+++ b/pipeline/transfer_validator.py
@@ -36,6 +36,7 @@ def transfer_validator(args):
     tf_dict = read_transfer(f"{meta.coupling_directory}/transfer_function.npz")
 
     nmt_binning = meta.read_nmt_binning()
+    nl = nmt_binning.lmax+1
     lb = nmt_binning.get_effective_ells()
 
     plot_dir = meta.plot_dir_from_output_dir(meta.coupling_directory)
@@ -131,16 +132,16 @@ def transfer_validator(args):
         bpw_mat = bp_win[f"bp_win_{spin_comb}"]
         for val_type in val_types:
             if spin_comb == "spin0xspin0":
-                cls_vec = np.array([cls_theory[val_type]["TT"][:meta.lmax+1]])
-                cls_vec = cls_vec.reshape(1, meta.lmax+1)
+                cls_vec = np.array([cls_theory[val_type]["TT"][:nl]])
+                cls_vec = cls_vec.reshape(1, nl)
             elif spin_comb == "spin0xspin2":
-                cls_vec = np.array([cls_theory[val_type]["TE"][:meta.lmax+1],
-                                    cls_theory[val_type]["TB"][:meta.lmax+1]])
+                cls_vec = np.array([cls_theory[val_type]["TE"][:nl],
+                                    cls_theory[val_type]["TB"][:nl]])
             elif spin_comb == "spin2xspin2":
-                cls_vec = np.array([cls_theory[val_type]["EE"][:meta.lmax+1],
-                                    cls_theory[val_type]["EB"][:meta.lmax+1],
-                                    cls_theory[val_type]["EB"][:meta.lmax+1],
-                                    cls_theory[val_type]["BB"][:meta.lmax+1]])
+                cls_vec = np.array([cls_theory[val_type]["EE"][:nl],
+                                    cls_theory[val_type]["EB"][:nl],
+                                    cls_theory[val_type]["EB"][:nl],
+                                    cls_theory[val_type]["BB"][:nl]])
 
             cls_vec_binned = np.einsum("ijkl,kl", bpw_mat, cls_vec)
             if spin_comb == "spin0xspin0":
@@ -203,7 +204,7 @@ def transfer_validator(args):
                 residual_filtered = \
                     (cls_mean_dict[val_type, "filtered", spec] -
                      cls_theory_binned[val_type, spec]) / \
-                    cls_std_dict[val_type, "unfiltered", spec]
+                    cls_std_dict[val_type, "filtered", spec]
 
                 sub.axhspan(-2, 2, color="gray", alpha=0.2)
                 sub.axhspan(-1, 1, color="gray", alpha=0.7)

--- a/soopercool/metadata_manager.py
+++ b/soopercool/metadata_manager.py
@@ -35,6 +35,11 @@ class BBmeta(object):
 
         # Set the general attributes (nside, lmax, etc...)
         self._set_general_attributes()
+        
+        # Copy the configuration file to output directory
+        import shutil
+        shutil.copyfile(fname_config, 
+                        self.output_dirs["root"]+"/paramfile_copy.yaml")
 
         # Basic sanity checks
         if self.lmax > 3*self.nside-1:

--- a/soopercool/metadata_manager.py
+++ b/soopercool/metadata_manager.py
@@ -35,10 +35,10 @@ class BBmeta(object):
 
         # Set the general attributes (nside, lmax, etc...)
         self._set_general_attributes()
-        
+
         # Copy the configuration file to output directory
         import shutil
-        shutil.copyfile(fname_config, 
+        shutil.copyfile(fname_config,
                         self.output_dirs["root"]+"/paramfile_copy.yaml")
 
         # Basic sanity checks

--- a/soopercool/metadata_manager.py
+++ b/soopercool/metadata_manager.py
@@ -37,9 +37,8 @@ class BBmeta(object):
         self._set_general_attributes()
 
         # Copy the configuration file to output directory
-        import shutil
-        shutil.copyfile(fname_config,
-                        self.output_dirs["root"]+"/paramfile_copy.yaml")
+        with open(f"{self.output_dirs['root']}/config.yaml", "w") as f:
+            yaml.dump(self.config, f)
 
         # Basic sanity checks
         if self.lmax > 3*self.nside-1:

--- a/soopercool/utils.py
+++ b/soopercool/utils.py
@@ -184,18 +184,12 @@ def beam_hpix(ll, nside):
     return beam_gaussian(ll, fwhm_hp_amin)
 
 
-def create_binning(lmin, lmax, delta_ell):
+def create_binning(nside, delta_ell):
     """
     """
-    bin_low = np.arange(lmin, lmax, delta_ell)
+    bin_low = np.arange(0, 3*nside, delta_ell)
     bin_high = bin_low + delta_ell - 1
-
-    idx = bin_high <= lmax
-    bin_low, bin_high = bin_low[idx], bin_high[idx]
-
-    if lmax not in bin_high:
-        bin_low = np.concatenate([bin_low, [bin_high[-1]+1]])
-        bin_high = np.concatenate([bin_high, [lmax]])
+    bin_high[-1] = 3*nside - 1
     bin_center = (bin_low + bin_high) / 2
 
     return bin_low, bin_high, bin_center


### PR DESCRIPTION
This PR fixes a longstanding bug affecting the transfer function, caused by the analysis mask being insufficiently apodized. 
It also solves an issue related to the ell-range of the mode coupling matrix: `NmtBin` now contains the multipole range `[0, 3*nside]` instead of being cut to the analysis range. 
The analysis mask is now either downloaded explicitly (this requires the user to check that the nhits map is compatible), or auto-assembled from the hits map (option `--self_assemble` of `mask_handler.py`).