### PR TITLE
Fix FileNotFoundError and improve url handling

### DIFF
--- a/pipeline/mask_handler.py
+++ b/pipeline/mask_handler.py
@@ -76,6 +76,8 @@ def mask_handler(args):
                 sat_apo_mask = hp.read_map(tmp_file.name, field=0)
                 sat_apo_mask = hp.ud_grade(sat_apo_mask, meta.nside)
                 meta.save_mask("analysis", sat_apo_mask, overwrite=True)
+                with open(sat_apo_file, 'w+b') as f:
+                    f.write(response.read())
     else:
         # Assemble custom analysis mask from hits map, Galactic mask and
         # point source mask

--- a/pipeline/mask_handler.py
+++ b/pipeline/mask_handler.py
@@ -8,6 +8,7 @@ import os
 import matplotlib.pyplot as plt
 from matplotlib import cm
 import urllib.request
+import pathlib
 
 
 def mask_handler(args):
@@ -24,9 +25,11 @@ def mask_handler(args):
 
     os.makedirs(mask_dir, exist_ok=True)
 
-    # Download hits map
     print("Download and save hits map ...")
     nhits_file = meta.hitmap_file
+    # Create hitmap_file directory if not exist
+    pathlib.Path(nhits_file).parent.mkdir(parents=True, exist_ok=True)
+    # Download hits map
     urlpref = "https://portal.nersc.gov/cfs/sobs/users/so_bb/"
     url = f"{urlpref}norm_nHits_SA_35FOV_ns512.fits"
     # Open the URL with a timeout


### PR DESCRIPTION
When downloading `hitmap_file` if the parent directory does not exist
it will raise FileNotFoundError.

`urllib.request.urlretrieve` is legacy interface it might be deprecated
in the future.
https://docs.python.org/3/library/urllib.request.html#urllib.request.urlretrieve

If downloaded fits files need `hp.ud_grade` download it to a temp file
following example:
https://docs.python.org/3/howto/urllib2.html#fetching-urls
The temp file will be removed when file closed.
This could avoid writing to disk twice.

If download directly to the disk, use simple file object operation.