### PR TITLE
External data (Planck) in SOOPERCOOL

### DIFF
--- a/paramfiles/paramfile_planck.yaml
+++ b/paramfiles/paramfile_planck.yaml
@@ -1,0 +1,126 @@
+# Here is a sample .yaml file that can be used 
+# to store the metadata necessary to run the
+# SO BB pipeline.
+
+# Define the directories
+## Let's start with directories of data products
+data_dirs:
+  root: "../data"
+  map_directory: "maps"
+  beam_directory: "beams"
+  bandpasses_directory: "bandpasses"
+## Then directories in which we will store outputs
+output_dirs: 
+  root: "../outputs"
+  mask_directory: "masks"
+  pre_process_directory: "pre_processing"
+  sims_directory: "sims"
+  cell_transfer_directory: "cells_transfer"
+  cell_data_directory: "cells_data"
+  cell_sims_directory: "cells_sims"
+  coupling_directory: "couplings"
+  covmat_directory: "covariances"
+
+##################################
+#    Metadata related to maps    #
+# ------------------------------ #
+#                                #
+# The structure of input splits  #
+# is the following:              #
+#                                #
+# tag:                           #
+#   file_root: ...               #
+#   n_splits: ...                #
+#   freq_tag: ...                #
+#   exp_tag: ...                 #
+##################################
+map_sets:
+  planck_f100:
+    file_root: "planck_f100"
+    n_splits: 2          # Number of splits
+    freq_tag: 100         # Freq. tag (e.g. useful to coadd freqs)
+    exp_tag: "planck"      # Experiment tag (useful to get noise-bias free cross-split spectra)
+  planck_f143:
+    file_root: "planck_f143"
+    n_splits: 2
+    freq_tag: 143
+    exp_tag: "planck"
+
+####################
+# Masking metadata #
+####################
+masks:
+  # Load nhits map from disk? Give absolute location here.
+  # If left blank, the mask handler will download the nominal nhits map.
+  input_nhits_path:
+
+  # Copies of all masks are stored under these names inside mask_directory
+  analysis_mask: "analysis_mask.fits"
+  nhits_map: "nhits_map.fits"
+  binary_mask: "binary_mask.fits"
+  galactic_mask_root: "planck_galactic_mask"
+  point_source_mask: "point_source_mask.fits"
+
+  include_in_mask: []
+  gal_mask_mode: "gal070"
+  apod_radius: 10.0
+  apod_radius_point_source: 4.0
+  apod_type: "C1"
+
+####################################
+# Metadata related to the analysis #
+####################################
+## General parameters
+general_pars:
+  nside: 256
+  lmin: 30
+  lmax: 600
+  deltal: 10
+  binning_file: "binning.npz"
+  pure_B: True
+
+## Simulation related
+sim_pars:
+  anisotropic_noise: False
+  null_e_modes: False
+  num_sims: 3
+  cosmology:
+    cosmomc_theta: 0.0104085
+    As: 2.1e-9
+    ombh2: 0.02237
+    omch2: 0.1200
+    ns: 0.9649
+    Alens: 1.0
+    tau: 0.0544
+    r: 0.01
+  mock_nsrcs: 80
+  mock_srcs_hole_radius: 40  
+
+## Filtering transfer function related parameters
+tf_settings:
+  filtering_type: "m_filterer"  # "m_filterer" or "toast"
+  m_cut: 30  # necessary only if `filtering_type` is set to "m_filterer"
+  toast:  # necessary only if `filtering_type` is set to "toast"
+    schedule: "../outputs/schedules/schedule_sat.txt"
+    instrument: "SAT1"
+    band: "SAT_f090"
+    thinfp: 8
+    group_size: 4
+
+  tf_est_num_sims: 4
+
+  power_law_pars_tf_est:
+    amp: 1.0
+    delta_ell: 10
+    power_law_index: 2.
+  
+  power_law_pars_tf_val:
+    amp:
+      TT: 10.
+      EE: 1.
+      BB: 0.05
+      TE: 2.5
+      TB: 0.
+      EB: 0.
+    delta_ell: 10
+    power_law_index: 0.5

--- a/pipeline/pre_processer_planck.py
+++ b/pipeline/pre_processer_planck.py
@@ -1,0 +1,253 @@
+import argparse
+from soopercool import BBmeta, utils
+import numpy as np
+import os
+import healpy as hp
+import matplotlib.pyplot as plt
+
+
+def pre_processer(args):
+    """
+    Pre-process Planck data to be compatible with SOOPERCOOL.
+    3 main operations:
+        - compute alms of original Planck maps (expensive part)
+        - rotate alms from galactic to equatorial coords
+        - downgrade maps to nside defined in paramfile
+    Planck sims are read (already downgraded and rotated) from NERSC.
+    If not found, they will be processed starting
+    from original maps as done with the data
+    ---------------------------------------------------------
+    output:
+        - Planck beams (for now, gaussian beams from FWHM)
+        - Planck downgraded data maps, rotated in equatorial coords
+        - (optional) Planck sims
+    """
+    
+    print("Pre-processing Planck NPIPE data")
+    meta = BBmeta(args.globals)
+    
+    npipe_dir = "/global/cfs/cdirs/cmb/data/planck2020/npipe"
+    data_dir = "../data"
+    sims_dir = meta.sims_directory
+    map_dir = meta.map_directory
+    beam_dir = meta.beam_directory
+    prep_dir = meta.pre_process_directory
+    alms_dir = prep_dir + "/planck/alms"
+    plots_dir = prep_dir + "/planck/plots"
+    mask_dir = meta.mask_directory
+    directories = [data_dir, sims_dir, map_dir,
+                   beam_dir, prep_dir, alms_dir,
+                   plots_dir, mask_dir]
+    for dirs in directories:
+        os.makedirs(dirs, exist_ok=True)
+    
+    binary_mask = meta.read_mask("binary")
+    fsky = np.mean(binary_mask)
+    
+    freqs = [] # ['030', '100', '143', '217', '353']
+    nside_out = meta.nside
+    lmax_out = 3*nside_out - 1
+    
+    print("Beams")
+    ells = np.arange(0, 3*nside_out+1, 1)
+    beam_arcmin = {'030':32.34, '100':9.66, '143':7.27, '217':5.01, '353':4.86}
+    beams = {}
+    
+    for map_set in meta.map_sets_list:
+        if 'planck' in map_set:
+            freq_tag = str(meta.freq_tag_from_map_set(map_set))
+            freqs.append(freq_tag)
+            beams[map_set] = utils.beam_gaussian(ells, beam_arcmin[freq_tag])
+            # Save beams
+            file_root = meta.file_root_from_map_set(map_set)
+            if not os.path.exists(file_root):
+                np.savetxt(f"{beam_dir}/beam_{file_root}.dat", np.transpose([ells, beams[map_set]]))
+    if args.plots:
+        for map_set in meta.map_sets_list:
+            if 'planck' in map_set:
+                plt.plot(ells, beams[map_set], label=str(map_set))
+        plt.xlabel(r'$\ell$')
+        plt.ylabel(r'$B_\ell$')
+        plt.title('Planck beams')
+        plt.legend(frameon=False)
+        plt.savefig(f'{plots_dir}/beams_planck.png')
+        plt.clf()
+    
+    splits = ['A', 'B']
+    splits_dict = {'A':0, 'B':1}
+    
+    # dipole amplitude, Galactic coordinates of the dipole direction
+    # from NPIPE paper, Solar dipole measurements, Table 11
+    dipole_amplitude = 3366.6
+    dipole_longitude = np.radians(263.986)
+    dipole_latitude = np.radians(48.247)
+    # Convert Galactic coordinates to Cartesian coordinates
+    x = np.cos(dipole_latitude) * np.cos(dipole_longitude)
+    y = np.cos(dipole_latitude) * np.sin(dipole_longitude)
+    z = np.sin(dipole_latitude)
+    
+    # alms of original maps
+    print("Computing alms of original maps")
+    meta.timer.start("Compute alms of original data maps")
+    for nu in freqs:
+        nside_in = 1024 if nu=='030' else 2048 # original maps nside
+        # Generate a dipole template (here because depending on input map nside)
+        dipole_template = dipole_amplitude * np.dot([x, y, z], hp.pix2vec(nside_in, np.arange(hp.nside2npix(nside_in))))
+        for split in splits:
+            print('---------------------')
+            print(f'channel {nu} - split {split}')
+            fname_in = npipe_dir + f'/npipe6v20{split}/npipe6v20{split}_{nu}_map.fits'
+            fname_out = alms_dir + f'/npipe6v20{split}/alms_npipe6v20{split}_{nu}_map_ns{nside_in}.npz'
+            if os.path.isfile(fname_out):
+                print('alms already computed, found at', fname_out)
+                continue
+            os.makedirs(alms_dir + f'/npipe6v20{split}', exist_ok=True)
+            
+            print('reading input maps at', fname_in)
+            m = 1e6 * hp.read_map(fname_in, field=[0,1,2]) # TQU, K to muK
+            print('removing dipole')
+            m[0] -= dipole_template
+            
+            print(f'computing alms, input map has nside={nside_in}')
+            alm = hp.map2alm(m, pol=True, use_pixel_weights=True)
+            print('writing alms to disk')
+            np.savez(fname_out, alm_T=alm[0], alm_E=alm[1], alm_B=alm[2])
+    meta.timer.stop("Compute alms of original data maps")
+    
+    # rotating and downgrading
+    # both operations carried out in harmonic space (alms)
+    # to conserve harmonic properties
+    print('---------------------')
+    print("Rotating and downgrading data maps")
+    meta.timer.start("Rotate and downgrade data maps")
+    angles = hp.rotator.coordsys2euler_zyz(coord = ["G", "C"])
+    for nu in freqs:
+        nside_in = 1024 if nu=='030' else 2048 # original alms nside
+        
+        # which alms indices to clip before downgrading
+        lmax_in = 3*nside_in - 1
+        clipping_indices = []
+        for m in range(lmax_out+1):
+            clipping_indices.append(hp.Alm.getidx(lmax_in, np.arange(m, lmax_out+1), m))
+        clipping_indices = np.concatenate(clipping_indices)
+        
+        for split in splits:
+            print('---------------------')
+            print(f'channel {nu} - split {split}')
+            fname_in = alms_dir + f'/npipe6v20{split}/alms_npipe6v20{split}_{nu}_map_ns{nside_in}.npz'
+            fname_out = map_dir + f'/planck_f{nu}_split_{splits_dict[split]}.fits'
+            if os.path.isfile(fname_out):
+                print('maps already rotated/downgraded, found at', fname_out)
+                continue
+            
+            print('reading alms at', fname_in)
+            alm_file = np.load(fname_in)
+            alm = np.array([alm_file['alm_T'], alm_file['alm_E'], alm_file['alm_B']])
+            
+            print('clipping alms') # clipping alms at l>lmax_out to avoid artifacts
+            alm_clipped = [each[clipping_indices] for each in alm]
+            
+            print('rotating alms from galactic to equatorial coords')
+            hp.rotate_alm(alm_clipped, *angles)
+            
+            print(f'downgrading to nside={nside_out}')
+            m_dg_rot = hp.alm2map(alm_clipped, nside=nside_out, pol=True)
+            
+            # mask Planck map with SO binary mask
+            m_masked = binary_mask * m_dg_rot
+            
+            print('writing maps to disk')
+            hp.write_map(fname_out, m_masked, overwrite=True, dtype=np.float32)
+            
+            if args.plots:
+                print('plotting maps')
+                utils.plot_map(m_masked, f"{plots_dir}/map_planck_f{nu}_split_{splits_dict[split]}",
+                               title=f'planck_f{nu}', TQU=True)
+    meta.timer.stop("Rotate and downgrade data maps")
+    
+    
+    if args.sims or args.noise:
+        print('---------------------')
+        print("Processing simulations" if not args.noise else "Processing noise simulations")
+        meta.timer.start("Process simulations")
+        # path to already downgraded and rotated npipe sims
+        npipe_sims_dir = f"/global/cfs/cdirs/sobs/users/cranucci/npipe/npipe_nside{nside_out}_coords_eq"
+        if os.path.isdir(npipe_sims_dir):
+            process_sims = False
+            sim_ids = [str(s).zfill(4) for s in range(meta.num_sims)]
+        else:
+            # process original npipe sims maps
+            process_sims = True
+            # path to original maps
+            npipe_sims_dir = npipe_dir
+            # npipe sims starting seed is 0200
+            sim_ids = [str(s).zfill(4) for s in range(200, 200+meta.num_sims)]
+        
+        for sim_id in sim_ids:
+            # changing starting seed from 0200 to 0000 (only if processing original maps)
+            sim_id_out = str( int(sim_id) - 200 ).zfill(4) if process_sims else sim_id
+            if args.noise:
+                os.makedirs(sims_dir + f'/{sim_id_out}/npipe_residual', exist_ok=True)
+            else:
+                os.makedirs(sims_dir + f'/{sim_id_out}', exist_ok=True)
+            for nu in freqs:
+                nside_in = 1024 if nu=='030' else 2048 # original maps nside
+                # which alms indices to clip before downgrading
+                lmax_in = 3*nside_in - 1
+                clipping_indices = []
+                for m in range(lmax_out+1):
+                    clipping_indices.append(hp.Alm.getidx(lmax_in, np.arange(m, lmax_out+1), m))
+                clipping_indices = np.concatenate(clipping_indices)
+                for split in splits:
+                    print('---------------------')
+                    print(f'sim {sim_id} - channel {nu} - split {split}')
+                    if args.noise:
+                        fname_in = npipe_sims_dir + f'/npipe6v20{split}_sim/{sim_id}/residual/residual_npipe6v20{split}_{nu}_{sim_id}.fits'
+                        fname_out = sims_dir + f'/{sim_id_out}/npipe_residual/planck_f{nu}_split_{splits_dict[split]}.fits'
+                    else:
+                        fname_in = npipe_sims_dir + f'/npipe6v20{split}_sim/{sim_id}/npipe6v20{split}_{nu}_map.fits'
+                        fname_out = sims_dir + f'/{sim_id_out}/planck_f{nu}_split_{splits_dict[split]}.fits'
+                    
+                    if os.path.isfile(fname_out):
+                        print('sims already rotated/downgraded, found at', fname_out)
+                        continue
+                    
+                    print('reading input maps at', fname_in)
+                    m = 1e6 * hp.read_map(fname_in, field=[0,1,2]) # TQU, K to muK
+                    
+                    if process_sims:
+                        # Generate a dipole template (here because depending on input map nside)
+                        dipole_template = dipole_amplitude * np.dot([x, y, z], hp.pix2vec(nside_in, np.arange(hp.nside2npix(nside_in))))
+                        # Subtract the dipole
+                        m[0] -= dipole_template
+                        print(f'computing alms, input map has nside={nside_in}')
+                        alm = hp.map2alm(m, pol=True, use_pixel_weights=True)
+                        print('clipping alms') # clipping alms at l>lmax_out to avoid artifacts
+                        alm_clipped = [each[clipping_indices] for each in alm]
+                        print('rotating alms from galactic to equatorial coords')
+                        hp.rotate_alm(alm_clipped, *angles)
+                        print(f'downgrading to nside={nside_out}')
+                        m = hp.alm2map(alm_clipped, nside=nside_out, pol=True)
+                    
+                    print('masking')
+                    m_masked = binary_mask * m
+                    print('writing maps to disk')
+                    hp.write_map(fname_out, m_masked, overwrite=True, dtype=np.float32)
+        meta.timer.stop("Process simulations")
+        print('---------------------')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Pre-processing Planck data/sims for the pipeline")
+    parser.add_argument("--globals", type=str,
+                        help="Path to the yaml with global parameters")
+    parser.add_argument("--sims", action="store_true",
+                        help="Pass to pre-process NPIPE simulations located at NERSC")
+    parser.add_argument("--noise", action="store_true",
+                        help="Pass to pre-process NPIPE noise sims located at NERSC")
+    parser.add_argument("--plots", action="store_true",
+                        help="Pass to generate plots")
+
+    args = parser.parse_args()
+    pre_processer(args)

--- a/pipeline/run_planck.sh
+++ b/pipeline/run_planck.sh
@@ -9,4 +9,4 @@ echo "------------------------------------------------------------"
 echo "Pre-processing data..."
 echo "-------------------"
 python mask_handler.py --globals ${paramfile}
-python pre_processer_planck.py --globals ${paramfile} --plots --sims # --noise # --process_sims
+python pre_processer_planck.py --globals ${paramfile} --plots --sims # --noise

--- a/pipeline/run_planck.sh
+++ b/pipeline/run_planck.sh
@@ -1,0 +1,12 @@
+paramfile='../paramfiles/paramfile_planck.yaml'
+
+echo "Running pipeline with paramfile: ${paramfile}"
+
+echo "------------------------------------------------------------"
+echo "|           PREPARING METADATA AND SIMULATIONS             |"
+echo "------------------------------------------------------------"
+
+echo "Pre-processing data..."
+echo "-------------------"
+python mask_handler.py --globals ${paramfile}
+python pre_processer_planck.py --globals ${paramfile} --plots --sims # --noise # --process_sims


### PR DESCRIPTION
Added a script ( `pre_processer_planck.py` ) for pre-processing Planck data for the pipeline. It reads Planck NPIPE maps from **NERSC**, rotates, downgrades, masks and saves them to disk. It does so for data and simulations/noise.